### PR TITLE
Codecov testing thing

### DIFF
--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: CodeCov
         uses: codecov/codecov-action@v1
-        if: matrix.os == 'ubuntu-latest' && matrix.jdk == 15 && github.repository == 'mysteraitch/javaparser'
+#        if: matrix.os == 'ubuntu-latest' && matrix.jdk == 15 && github.repository == 'mysteraitch/javaparser'
         timeout-minutes: 10
         with:
           files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -76,5 +76,5 @@ jobs:
           files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: false # optional (default = false):
-          flags: AlsoSlowTests,aggregate,OS,JDK
+          flags: AlsoSlowTests,aggregate,${{ runner.os }},jdk-${{ runner.jdk }}
           env_vars: AlsoSlowTests,aggregate,OS,JDK

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -76,5 +76,5 @@ jobs:
           files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: false # optional (default = false):
-          flags: AlsoSlowTests,aggregate,${{ runner.os }},jdk-${{ runner.jdk }}
+          flags: AlsoSlowTests,${{ runner.os }},jdk-${{ runner.jdk }}
           env_vars: AlsoSlowTests,aggregate,OS,JDK

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -68,15 +68,12 @@ jobs:
       - name: Test with Maven (incl. slow tests)
         run: mvn --errors clean test --activate-profiles AlsoSlowTests
 
-      - name: Generate jacoco reports
-        run: mvn -e -B jacoco:report-aggregate
-
       - name: CodeCov
         uses: codecov/codecov-action@v1
         if: matrix.os == 'ubuntu-latest' && matrix.jdk == 15 && github.repository == 'mysteraitch/javaparser'
         timeout-minutes: 10
         with:
-          file: target/site/jacoco-aggregate/jacoco.xml
+          files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: false # optional (default = false):
           flags: AlsoSlowTests,aggregate,OS,JDK

--- a/.github/workflows/maven_tests.yml
+++ b/.github/workflows/maven_tests.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         ## Different OSs have different default line-endings -- test on all combinations.
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         ## Different JDK versions have different implementations etc. -- test on all combinations (ideally 8 to latest).
         ### exclude pre-8 (min development version jdk8)
         ### exclude post-12 (changes to jdk causes reflection tests to fail due to added methods #1701 )
-        jdk: [15]
+        jdk: [8,9,10,11,12,13,14,15]
     env:
       OS: ${{ matrix.os }}
       JDK: ${{ matrix.jdk }}
@@ -76,5 +76,5 @@ jobs:
           files: javaparser-core-testing/target/site/jacoco/jacoco.xml,javaparser-core-testing-bdd/target/site/jacoco/jacoco.xml,javaparser-symbol-solver-core/target/site/jacoco-aggregate/jacoco.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: false # optional (default = false):
-          flags: AlsoSlowTests,${{ runner.os }},jdk-${{ runner.jdk }}
+          flags: AlsoSlowTests,${{ matrix.os }},jdk-${{ matrix.jdk }}
           env_vars: AlsoSlowTests,aggregate,OS,JDK

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -64,6 +64,23 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/javaparser-core-testing-bdd/pom.xml
+++ b/javaparser-core-testing-bdd/pom.xml
@@ -48,8 +48,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -47,8 +47,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>

--- a/javaparser-core-testing/pom.xml
+++ b/javaparser-core-testing/pom.xml
@@ -63,6 +63,23 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -93,6 +93,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>copy-javaparser-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-core/target/generated-sources</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-javaparser-symbol-solver-core-classes</id>
                         <phase>compile</phase>
                         <goals>
@@ -104,6 +121,23 @@
                             <resources>
                                 <resource>
                                     <directory>../javaparser-symbol-solver-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-symbol-solver-core-generated-sources</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/generated-sources/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-symbol-solver-core/target/generated-sources</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>

--- a/javaparser-symbol-solver-testing/pom.xml
+++ b/javaparser-symbol-solver-testing/pom.xml
@@ -76,8 +76,8 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>pre-integration-test</phase>
+                        <id>copy-javaparser-core-classes</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -87,6 +87,23 @@
                             <resources>
                                 <resource>
                                     <directory>../javaparser-core/target/classes</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-javaparser-symbol-solver-core-classes</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../javaparser-symbol-solver-core/target/classes</directory>
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>


### PR DESCRIPTION
jacoco doesn't run in the testing submodules, without access to the built sources (copied) from the other submodules